### PR TITLE
Update vim fuction names

### DIFF
--- a/plugin/floo/view.py
+++ b/plugin/floo/view.py
@@ -114,7 +114,7 @@ class View(object):
 
     def get_selections(self):
         # Vim likes to return strings for numbers even if you use str2nr:
-        return [[int(pos) for pos in range_] for range_ in vim.eval("g:floobits_get_selection()")]
+        return [[int(pos) for pos in range_] for range_ in vim.eval("g:FloobitsGetSelection()")]
 
     def clear_highlight(self, user_id):
         msg.debug('clearing selections for user %s in view %s' % (user_id, self.vim_buf.name))

--- a/plugin/floobits.py
+++ b/plugin/floobits.py
@@ -67,7 +67,7 @@ ticker_errors = 0
 using_feedkeys = False
 
 ticker_python = '''import sys; import subprocess; import time
-args = ['{binary}', '--servername', '{servername}', '--remote-expr', 'g:floobits_global_tick()']
+args = ['{binary}', '--servername', '{servername}', '--remote-expr', 'g:FloobitsGlobalTick()']
 while True:
     time.sleep({sleep})
     # TODO: learn to speak vim or something :(

--- a/plugin/vimbits.vim
+++ b/plugin/vimbits.vim
@@ -7,7 +7,7 @@ if !has('python')
     finish
 endif
 
-if exists("g:floobits_plugin_loaded")
+if exists("g:FloobitsPluginLoaded")
     finish
 endif
 
@@ -25,12 +25,12 @@ if !exists("floo_sparse_mode")
 endif
 
 " p flag expands the absolute path. Sorry for the global
-let g:floobits_plugin_dir = expand("<sfile>:p:h")
+let g:FloobitsPluginDir = expand("<sfile>:p:h")
 
 python << END_PYTHON
 import os, sys
 import vim
-sys.path.append(vim.eval("g:floobits_plugin_dir"))
+sys.path.append(vim.eval("g:FloobitsPluginDir"))
 
 END_PYTHON
 
@@ -38,7 +38,7 @@ if filereadable(expand("<sfile>:p:h")."/floobits_wrapper.py")
     pyfile <sfile>:p:h/floobits_wrapper.py
 else
     echohl WarningMsg |
-    \ echomsg "Floobits plugin error: Can't find floobits.py in ".g:floobits_plugin_dir |
+    \ echomsg "Floobits plugin error: Can't find floobits.py in ".g:FloobitsPluginDir |
     \ echohl None
     finish
 endif
@@ -52,11 +52,11 @@ function! g:FlooSetReadOnly()
     setlocal nomodifiable
 endfunction
 
-function! g:floobits_global_tick()
+function! g:FloobitsGlobalTick()
     python floobits_global_tick()
 endfunction
 
-function! g:floobits_get_selection()
+function! g:FloobitsGetSelection()
     let m = tolower(mode())
     try
         if 'v' == m
@@ -138,5 +138,5 @@ command! -nargs=? -complete=file FlooAddBuf :python floobits_add_buf(<f-args>)
 command! FlooInfo :python floobits_info()
 
 call s:SetAutoCmd()
-let g:floobits_plugin_loaded = 1
+let g:FloobitsPluginLoaded = 1
 python floobits_check_credentials()


### PR DESCRIPTION
To conform with new vim patch (Patch 7.4.260) which specifies that g: functions need to start with a capital letters.

Just updated vim to 7.4.273 and plugin freaked out. Changed all g:functions to CamelCase

Patch details are here: https://groups.google.com/forum/#!topic/vim_dev/M4_E1QhXVxA
